### PR TITLE
phpctags runs out of memory when executed on extremely large PHP files

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -225,9 +225,32 @@ class PHPCtags
 
     public function export($file, $options)
     {
+        // if the memory limit option is set and is valid, adjust memory
+        if (isset($options['memory'])) {
+            $memory_limit = trim($options['memory']);
+            if ($this->testValidMemoryLimit($memory_limit)) {
+                ini_set('memory_limit', $memory_limit);
+            }
+        }
         //@todo Check for existence
         $this->mFile = $file;
         $structs = $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE);
         echo $this->render($structs, $options);
+    }
+
+    private static function testValidMemoryLimit($memory_limit) {
+        if ($memory_limit == "-1") {
+            // no memory limit
+            return true;
+        } elseif (is_numeric($memory_limit) && $memory_limit > 0) {
+            // memory limit provided in bytes
+            return true;
+        } elseif (preg_match("/\d+\s*[KMG]/", $memory_limit)) {
+            // memory limit provided in human readable sizes
+            // as specified here: http://www.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+            return true;
+        }
+
+        return false;
     }
 }

--- a/phpctags
+++ b/phpctags
@@ -18,6 +18,7 @@ $options = getopt('f:',array(
     'fields::',
     'format::',
     'version',
+    'memory::',
 ));
 
 if(!isset($options['debug'])) {
@@ -41,6 +42,8 @@ if(!isset($options['excmd']))
     $options['excmd'] = 'pattern';
 if(!isset($options['format']))
     $options['format'] = 2;
+if(isset($options['memory']))
+    $options['memory'] = '128M';
 if(!isset($options['fields'])) {
     $options['fields'] = array('n', 'k','s', 'a');
 } else {


### PR DESCRIPTION
```
Error detected while processing function <SNR>72_AutoUpdate..<SNR>72_ProcessFile..<SNR>72_ExecuteCtagsOnFile:
Tagbar: Could not execute ctags for /tmp/vPr9mty/3.php!
Executed command: "'/home/DeMarko/bin/phpctags/phpctags'    '/tmp/vPr9mty/3.php'"
Fatal error: Allowed memory size of 67108864 bytes exhausted (tried to allocate 2097152 bytes) in /home/DeMarko/bin/phpctags/vendor/nikic/php-parser/lib/PHPParser/Node/Scalar/String.php on line 58
```

Parsing large files requires a lot more memory than the PHP default. Other utilities such as phpcs allow you to specify the php ini definition flag (-d) while invoking the script.

There are two ways to fix this issue afaict:
- pass on the -d config to phpctags that lets you set an arbitrary memory definition (`-d memory_limit=512M`, for example)
- just increase the memory limit of the script `ini_set('memory_limit', '512M');`
