### PR TITLE
add memory limit support in phpctags

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -225,9 +225,32 @@ class PHPCtags
 
     public function export($file, $options)
     {
+        // if the memory limit option is set and is valid, adjust memory
+        if (isset($options['memory'])) {
+            $memory_limit = trim($options['memory']);
+            if ($this->testValidMemoryLimit($memory_limit)) {
+                ini_set('memory_limit', $memory_limit);
+            }
+        }
         //@todo Check for existence
         $this->mFile = $file;
         $structs = $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE);
         echo $this->render($structs, $options);
+    }
+
+    private static function testValidMemoryLimit($memory_limit) {
+        if ($memory_limit == "-1") {
+            // no memory limit
+            return true;
+        } elseif (is_numeric($memory_limit) && $memory_limit > 0) {
+            // memory limit provided in bytes
+            return true;
+        } elseif (preg_match("/\d+\s*[KMG]/", $memory_limit)) {
+            // memory limit provided in human readable sizes
+            // as specified here: http://www.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+            return true;
+        }
+
+        return false;
     }
 }

--- a/phpctags
+++ b/phpctags
@@ -18,6 +18,7 @@ $options = getopt('f:',array(
     'fields::',
     'format::',
     'version',
+    'memory::',
 ));
 
 if(!isset($options['debug'])) {
@@ -41,6 +42,8 @@ if(!isset($options['excmd']))
     $options['excmd'] = 'pattern';
 if(!isset($options['format']))
     $options['format'] = 2;
+if(isset($options['memory']))
+    $options['memory'] = '128M';
 if(!isset($options['fields'])) {
     $options['fields'] = array('n', 'k','s', 'a');
 } else {


### PR DESCRIPTION
Use the known memory limit adjustments (-1, positive integers or bytes
and human readable sizes) to adjust the memory used during the parsing
and lexing that occurs in phpctags

Related to issue #5 and techlivezheng/tagbar-phpctags#1
