### PR TITLE
Fix autoloader.php path

### DIFF
--- a/phpctags
+++ b/phpctags
@@ -1,9 +1,9 @@
 #!/usr/bin/php -q
 <?php
-if (is_dir($vendor = __DIR__ . '/vendor')) {
-    require($vendor . '/autoload.php');
-} elseif (is_dir($vendor = __DIR__ . '/../../../vendor')) {
-    require($vendor . '/autoload.php');
+if (file_exists($autoload = __DIR__ . '/vendor/autoload.php')) {
+    require($autoload);
+} elseif (file_exists($autoload = __DIR__ . '/../../autoload.php')) {
+    require($autoload);
 } else {
     die(
         'You must set up the project dependencies, run the following commands:'.PHP_EOL.


### PR DESCRIPTION
The Composer checkout directory does not have to be called `vendor`. User can overwrite it. So instead of looking for the `vendor` dir, look for the `autoload.php` file directly.
