### PR TITLE
Add namespace support for phpctags

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -15,6 +15,7 @@ class PHPCtags
         'd' => 'constant',
         'v' => 'variable',
         'i' => 'interface',
+        'n' => 'namespace',
     );
 
     private $mParser;


### PR DESCRIPTION
I play around the patched ctags, and reference it's namespace implementation. Finally, I came up this.

It should generate the same result as patched ctags.
