### PR TITLE
Add trait support for phpctags

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -15,6 +15,7 @@ class PHPCtags
         'd' => 'constant',
         'v' => 'variable',
         'i' => 'interface',
+        't' => 'trait',
     );
 
     private $mParser;
@@ -180,6 +181,13 @@ class PHPCtags
             $line = $node->getLine();
             foreach ($node as $subNode) {
                 $this->struct($subNode, FALSE, array('interface' => $name));
+            }
+        } elseif ($node instanceof PHPParser_Node_Stmt_Trait ) {
+            $kind = 't';
+            $name = $node->name;
+            $line = $node->getLine();
+            foreach ($node as $subNode) {
+                $this->struct($subNode, FALSE, array('trait' => $name));
             }
         } elseif ($node instanceof PHPParser_Node_Stmt_Namespace) {
             //@todo


### PR DESCRIPTION
Add trait support for phpctags, it can generate the same result as patched ctags.

But, I think we still need to parse "use <trait>" statement, or there is no way to know which class use which trait.  *\* patched ctags doesn't do this.
