### PR TITLE
Update makefile to not care about user's php.ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,13 @@ build:
 
 build/composer.phar: | build
 	@echo "Installing composer ..."
-	@curl -s http://getcomposer.org/installer | php -- --install-dir=build
+	@curl -s http://getcomposer.org/installer | \
+		  php -dextension=phar.so -dextension=openssl.so -- --install-dir=build \
+		  -dextension=phar.so
 
 vendor: composer.lock build/composer.phar
 	@echo "Installing vendor libraries ..."
-	@php build/composer.phar install
+	@php -dextension=phar.so -dextension=openssl.so build/composer.phar install
 	@touch vendor/
 
 build/phpctags.phar: vendor $(source) | build


### PR DESCRIPTION
Add explicit inclusion of required PHP extensions for build so the user
doesn't have to edit php.ini to make.

This goes beyond simplifying the step of building things - it also will
allow for packaging in the Arch Linux user repository - which I am
currently creating a package for.
