### PR TITLE
Performance improvements, caching and drupal extensions

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -290,7 +290,10 @@ class PHPCtags
             if ($this->mOptions['excmd'] == 'number') {
                 $str .= "\t" . $struct['line'];
             } else { //excmd == 'mixed' or 'pattern', default behavior
-                $str .= "\t" . "/^" . rtrim($lines[$struct['line'] - 1], "\n") . "$/";
+                $line = rtrim($lines[$struct['line'] - 1], "\n");
+                $line = str_replace('\\', '\\\\\\', $line);
+                $line = preg_replace('|(?<!\\\\)/|', '\/', $line);
+                $str .= "\t" . "/^" . $line . "$/";
             }
 
             if ($this->mOptions['format'] == 1) {

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -429,7 +429,9 @@ class PHPCtags
                 )
             );
 
-            $extensions = array('.php', '.php3', '.php4', '.php5', '.phps');
+            // File list includes default php extensions plug the Drupal extra extensions.
+            $extensions = array('.php', '.php3', '.php4', '.php5', '.phps', '.module',
+                                '.inc', '.install', '.test', '.profile', '.theme', '.txt', '.js', '.css');
 
             foreach ($iterator as $filename) {
                 if (!in_array(substr($filename, strrpos($filename, '.')), $extensions)) {

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -21,15 +21,22 @@ class PHPCtags
 
     private $mParser;
 
-    private $mStructs;
+    private $mLines;
 
     private $mOptions;
+
+    private $tagdata;
+
+    private $cachefile;
+
+    private $filecount;
 
     public function __construct($options)
     {
         $this->mParser = new PHPParser_Parser(new PHPParser_Lexer);
-        $this->mStructs = array();
+        $this->mLines = array();
         $this->mOptions = $options;
+        $this->filecount = 0;
     }
 
     public function setMFile($file)
@@ -57,6 +64,10 @@ class PHPCtags
     public function addFile($file)
     {
         $this->mFiles[realpath($file)] = 1;
+    }
+
+    public function setCacheFile($file) {
+        $this->cachefile = $file;
     }
 
     public function addFiles($files)
@@ -250,10 +261,10 @@ class PHPCtags
         return $structs;
     }
 
-    private function render()
+    private function render($structure)
     {
         $str = '';
-        foreach ($this->mStructs as $struct) {
+        foreach ($structure as $struct) {
             $file = $struct['file'];
 
             if (!isset($files[$file]))
@@ -360,11 +371,29 @@ class PHPCtags
         // remove the last line ending
         $str = trim($str);
 
+        return $str;
+    }
+
+    private function full_render() {
+        // Files will have been rendered already, just join and export.
+
+        $str = '';
+        foreach($this->mLines as $file => $data) {
+          $str .= $data;
+        }
+
         // sort the result as instructed
         if (isset($this->mOptions['sort']) && ($this->mOptions['sort'] == 'yes' || $this->mOptions['sort'] == 'foldcase')) {
             $str = self::stringSortByLine($str, $this->mOptions['sort'] == 'foldcase');
         }
 
+        // Save all tag information to a file for faster updates if a cache file was specified.
+        if (isset($this->cachefile)) {
+            file_put_contents($this->cachefile, serialize($this->tagdata));
+            if ($this->mOptions['v']) {
+                echo "Saved cache file.\n";
+            }
+        }
         return $str;
     }
 
@@ -378,11 +407,19 @@ class PHPCtags
             $this->process($file);
         }
 
-        return $this->render();
+        return $this->full_render();
     }
 
     private function process($file)
     {
+        // Load the tag md5 data to skip unchanged files.
+        if (!isset($this->tagdata) && isset($this->cachefile) && file_exists($this->cachefile)) {
+            if ($this->mOptions['v']) {
+                echo "Loaded cache file.\n";
+            }
+            $this->tagdata = unserialize(file_get_contents($this->cachefile));
+        }
+
         if (is_dir($file) && isset($this->mOptions['R'])) {
             $iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator(
@@ -404,27 +441,53 @@ class PHPCtags
                 }
 
                 try {
-                    $this->setMFile((string) $filename);
-                    $this->mStructs = array_merge(
-                        $this->mStructs,
-                        $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
-                    );
+                    $this->process_single_file($filename);
                 } catch(Exception $e) {
                     echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
                 }
             }
         } else {
             try {
-                $this->setMFile($file);
-                $this->mStructs = array_merge(
-                    $this->mStructs,
-                    $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
-                );
+                    $this->process_single_file($filename);
             } catch(Exception $e) {
                 echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
             }
         }
     }
+
+    private function process_single_file($filename)
+    {
+        if ($this->mOptions['v'] && $this->filecount > 1 && $this->filecount % 64 == 0) {
+            echo " ".$this->filecount." files\n";
+        }
+        $this->filecount++;
+
+        $startfile = microtime(true);
+
+        $this->setMFile((string) $filename);
+        $file = file_get_contents($this->mFile);
+        $md5 = md5($file);
+        if (isset($this->tagdata[$this->mFile][$md5])) {
+            // The file is the same as the previous time we analyzed and saved.
+            $this->mLines[$this->mFile] = $this->tagdata[$this->mFile][$md5];
+            if ($this->mOptions['v']) {
+                echo ".";
+            }
+            return;
+        }
+
+        $struct = $this->struct($this->mParser->parse($file), TRUE);
+        $finishfile = microtime(true);
+        $this->mLines[$this->mFile] = $this->render($struct);
+        $finishmerge = microtime(true);
+        $this->tagdata[$this->mFile][$md5] = $this->mLines[$this->mFile];
+        if ($this->mOptions['debug']) {
+            echo "Parse: ".($finishfile - $startfile).", Merge: ".($finishmerge-$finishfile)."; (".$this->filecount.")".$this->mFile."\n";
+        } else if ($this->mOptions['v']) {
+            echo "U";
+        }
+    }
+
 }
 
 class PHPCtagsException extends Exception {

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -454,7 +454,7 @@ class PHPCtags
 
         if (is_dir($file) && isset($this->mOptions['R'])) {
             $iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator(
+                new ReadableRecursiveDirectoryIterator(
                     $file,
                     FilesystemIterator::SKIP_DOTS |
                     FilesystemIterator::FOLLOW_SYMLINKS
@@ -527,3 +527,14 @@ class PHPCtagsException extends Exception {
         return "\nPHPCtags: {$this->message}\n";
     }
 }
+
+class ReadableRecursiveDirectoryIterator extends RecursiveDirectoryIterator {
+    function getChildren() {
+        try {
+            return new ReadableRecursiveDirectoryIterator($this->getPathname());
+        } catch(UnexpectedValueException $e) {
+            echo "\nPHPPCtags: {$e->getMessage()} - {$this->getPathname()}\n";
+            return new RecursiveArrayIterator(array());
+        }
+    }
+} 

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -390,17 +390,6 @@ class PHPCtags
 
         $str = '';
         foreach($this->mLines as $file => $data) {
-          $str .= $data."\n";
-        }
-
-        return $str;
-    }
-
-    private function full_render() {
-        // Files will have been rendered already, just join and export.
-
-        $str = '';
-        foreach($this->mLines as $file => $data) {
           $str .= $data;
         }
 
@@ -469,7 +458,7 @@ class PHPCtags
                     continue;
                 }
 
-                if (isset($this->mOptions['exclude']) && false !== strpos($filename, $this->mOptions['exclude'])) {
+                if ($this->isExcludedFile($filename)) {
                     continue;
                 }
 
@@ -523,6 +512,26 @@ class PHPCtags
         }
     }
 
+    private function isExcludedFile($filename)
+    {
+        if (!isset($this->mOptions['exclude'])) {
+            return false;
+        }
+
+        if (is_string($this->mOptions['exclude'])) {
+            return false !== strpos($filename, $this->mOptions['exclude']);
+        }
+
+        if (is_array($this->mOptions['exclude'])) {
+            foreach ($this->mOptions['exclude'] as $excludePattern) {
+                if (false !== strpos($filename, $excludePattern)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }
 
 class PHPCtagsException extends Exception {

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Using [PHP_Parser](https://github.com/nikic/PHP-Parser) as PHP syntax parsing
 backend, written in pure PHP. The generated ctags index file contains scope
 and access information about class's methods and properties.
 
-This tool was originally developed to enhance the PHP syntax outline surport
-for vim [tagbar](http://majutsushi.github.com/tagbar/) plugin. The enhaced
+This tool was originally developed to enhance the PHP syntax outline support
+for vim [tagbar](http://majutsushi.github.com/tagbar/) plugin. The enhanced
 functionality has been included into an addon plugin for tagbar as
 [tagbar-phpctags](https://github.com/techlivezheng/tagbar-phpctags).
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -29,7 +29,9 @@ $options = getopt('aC:f:Nno:RuvV', array(
     'recurse::',
     'sort::',
     'version',
+    'extensions:',
     'memory::',
+    'verbose'
 ));
 
 $options_info = <<<'EOF'
@@ -56,6 +58,8 @@ Usage: phpctags [options] [file(s)]
        Repect PHP's error level configuration.
   --exclude=pattern
       Exclude files and directories matching 'pattern'.
+  --extensions=string
+      Process the file extensions. ['.php .php3 .php4 .php5 .phps'].
   --excmd=number|pattern|mix
        Uses the specified type of EX command to locate tags [mix].
   --fields=[+|-]flags
@@ -71,6 +75,8 @@ Usage: phpctags [options] [file(s)]
        Recurse into directories supplied on command line [no].
   --sort=[yes|no|foldcase]
        Should tags be sorted (optionally ignoring case) [yes]?.
+  --verbose
+       Display more output about progress.
   --version
        Print version identifier to standard output.
 EOF;
@@ -138,6 +144,10 @@ if (isset($options['N']) && !isset($options['n'])) {
     $options['excmd'] = 'pattern';
 }
 
+if (isset($options['v']) || isset($options['verbose']))
+    $options['verbose'] = true;
+else
+    $options['verbose'] = false;
 if (!isset($options['excmd']))
     $options['excmd'] = 'pattern';
 if (!isset($options['format']))

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -32,7 +32,6 @@ $options = getopt('aC:f:Nno:RuV', array(
     'version',
     'extensions:',
     'memory::',
-    'verbose'
 ));
 
 $options_info = <<<'EOF'

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -18,7 +18,7 @@ Exuberant Ctags compatiable PHP enhancement, Copyright (C) 2012 Techlive Zheng
 Addresses: <techlivezheng@gmail.com>, https://github.com/techlivezheng/phpctags
 EOF;
 
-$options = getopt('af:Nno:RuV', array(
+$options = getopt('aC:f:Nno:RuvV', array(
     'append::',
     'debug',
     'exclude:',
@@ -41,12 +41,14 @@ Usage: phpctags [options] [file(s)]
   -f <name>
        Write tags to specified file. Value of "-" writes tags to stdout
        ["tags"].
+  -C <name>
+       Use a cache file to store tags for faster updates.
   -n   Equivalent to --excmd=number.
   -N   Equivalent to --excmd=pattern.
   -o   Alternative for -f.
   -R   Equivalent to --recurse.
   -u   Equivalent to --sort=no.
-  -V   Equivalent to --verbose.
+  -v   Equivalent to --verbose.
   --append=[yes|no]
        Should tags should be appended to existing tag file [no]?
   --debug
@@ -75,6 +77,7 @@ EOF;
 
 // prune options and its value from the $argv array
 $argv_ = array();
+
 foreach ($options as $option => $value) {
   foreach ($argv as $key => $chunk) {
     $regex = '/^'. (isset($option[1]) ? '--' : '-') . $option . '/';
@@ -201,6 +204,7 @@ if (isset($options['R']) && empty($argv)) {
 try {
     $ctags = new PHPCtags($options);
     $ctags->addFiles($argv);
+    $ctags->setCacheFile(isset($options['C']) ? $options['C'] : null);
     $result = $ctags->export();
 } catch (Exception $e) {
     die("phpctags: {$e->getMessage()}".PHP_EOL);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -18,7 +18,7 @@ Exuberant Ctags compatiable PHP enhancement, Copyright (C) 2012 Techlive Zheng
 Addresses: <techlivezheng@gmail.com>, https://github.com/techlivezheng/phpctags
 EOF;
 
-$options = getopt('aC:f:Nno:RuvV', array(
+$options = getopt('aC:f:Nno:RuV', array(
     'append::',
     'debug',
     'exclude:',
@@ -28,6 +28,7 @@ $options = getopt('aC:f:Nno:RuvV', array(
     'help',
     'recurse::',
     'sort::',
+    'verbose::',
     'version',
     'extensions:',
     'memory::',
@@ -75,8 +76,8 @@ Usage: phpctags [options] [file(s)]
        Recurse into directories supplied on command line [no].
   --sort=[yes|no|foldcase]
        Should tags be sorted (optionally ignoring case) [yes]?.
-  --verbose
-       Display more output about progress.
+  --verbose=[yes|no]
+       Enable verbose messages describing actions on each source file.
   --version
        Print version identifier to standard output.
 EOF;
@@ -94,9 +95,17 @@ foreach ($options as $option => $value) {
 }
 while ($key = array_pop($argv_)) unset($argv[$key]);
 
-// option -V is an alternative to --version
+// option -V is an alternative to --verbose
 if (isset($options['V'])) {
-    $options['version'] = FALSE;
+    $options['verbose'] = 'yes';
+}
+
+if (isset($options['verbose'])) {
+    if ($options['verbose'] === FALSE || yes_or_no($options['verbose']) == 'yes') {
+        $options['V'] = 'yes';
+    } else if (yes_or_no($options['verbose']) != 'no') {
+        die('phpctags: Invalid value for "verbose" option'.PHP_EOL);
+    }
 }
 
 if (!isset($options['debug'])) {

--- a/buildPHAR.php
+++ b/buildPHAR.php
@@ -34,6 +34,7 @@ $phar->buildFromIterator(
                     'build/*',
                     'tests/*',
                     'Makefile',
+                    'phpctags',
                     'phpctags.sh',
                     'buildPHAR.php',
                 );


### PR DESCRIPTION
PHPCtags has been labelled as slow and it was taking over an hour to process the entire Moodle sources.  This makes it unusable on a large project.

I've adjusted the method used for storing data to reduce the memory footprint and reduce the time to build.  On the same hardware, Moodle now does a full tags build in under 4 minutes.

For general tag updates, 4 minutes is too long as well.  So now there is a caching file option that will store versions of your files tags.  So when you git co <branch>, it will cache both versions allowing for fast update.  Branch changes and/or updates with no changes are running in 1-3 seconds for Moodle sources on the same hardware as the above tests.

Memory has not specifically been benchmarked, looking at top, it appears to be less, even with the cache file loaded in memory.