### PR TITLE
Performance tweak

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -405,10 +405,11 @@ class PHPCtags
 
                 try {
                     $this->setMFile((string) $filename);
-                    $this->mStructs = array_merge(
-                        $this->mStructs,
-                        $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
-                    );
+                    $structs = $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE);
+                    foreach($structs as $struct)
+                    {
+                        $this->mStructs[] = $struct;
+                    }
                 } catch(Exception $e) {
                     echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
                 }
@@ -416,10 +417,11 @@ class PHPCtags
         } else {
             try {
                 $this->setMFile($file);
-                $this->mStructs = array_merge(
-                    $this->mStructs,
-                    $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
-                );
+                $structs = $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE);
+                foreach($structs as $struct)
+                {
+                    $this->mStructs[] = $struct;
+                }
             } catch(Exception $e) {
                 echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
             }


### PR DESCRIPTION
Hi  @techlivezheng

I replaced `array_merge()` with `foreach($elems as $elem) {$array[]=$elem;}`, it makes phpctags 3 times faster.

In my case, it just reduced the time from 15 minutes to 5 minutes.

Mark
