### PR TITLE
Performance tweak based on @mr-russ's PR

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -21,15 +21,22 @@ class PHPCtags
 
     private $mParser;
 
-    private $mStructs;
+    private $mLines;
 
     private $mOptions;
+
+    private $tagdata;
+
+    private $cachefile;
+
+    private $filecount;
 
     public function __construct($options)
     {
         $this->mParser = new PHPParser_Parser(new PHPParser_Lexer);
-        $this->mStructs = array();
+        $this->mLines = array();
         $this->mOptions = $options;
+        $this->filecount = 0;
     }
 
     public function setMFile($file)
@@ -57,6 +64,10 @@ class PHPCtags
     public function addFile($file)
     {
         $this->mFiles[realpath($file)] = 1;
+    }
+
+    public function setCacheFile($file) {
+        $this->cachefile = $file;
     }
 
     public function addFiles($files)
@@ -250,10 +261,10 @@ class PHPCtags
         return $structs;
     }
 
-    private function render()
+    private function render($structure)
     {
         $str = '';
-        foreach ($this->mStructs as $struct) {
+        foreach ($structure as $struct) {
             $file = $struct['file'];
 
             if (!isset($files[$file]))
@@ -360,11 +371,29 @@ class PHPCtags
         // remove the last line ending
         $str = trim($str);
 
+        return $str;
+    }
+
+    private function full_render() {
+        // Files will have been rendered already, just join and export.
+
+        $str = '';
+        foreach($this->mLines as $file => $data) {
+          $str .= $data;
+        }
+
         // sort the result as instructed
         if (isset($this->mOptions['sort']) && ($this->mOptions['sort'] == 'yes' || $this->mOptions['sort'] == 'foldcase')) {
             $str = self::stringSortByLine($str, $this->mOptions['sort'] == 'foldcase');
         }
 
+        // Save all tag information to a file for faster updates if a cache file was specified.
+        if (isset($this->cachefile)) {
+            file_put_contents($this->cachefile, serialize($this->tagdata));
+            if ($this->mOptions['v']) {
+                echo "Saved cache file.\n";
+            }
+        }
         return $str;
     }
 
@@ -378,11 +407,19 @@ class PHPCtags
             $this->process($file);
         }
 
-        return $this->render();
+        return $this->full_render();
     }
 
     private function process($file)
     {
+        // Load the tag md5 data to skip unchanged files.
+        if (!isset($this->tagdata) && isset($this->cachefile) && file_exists($this->cachefile)) {
+            if ($this->mOptions['v']) {
+                echo "Loaded cache file.\n";
+            }
+            $this->tagdata = unserialize(file_get_contents($this->cachefile));
+        }
+
         if (is_dir($file) && isset($this->mOptions['R'])) {
             $iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator(
@@ -404,27 +441,53 @@ class PHPCtags
                 }
 
                 try {
-                    $this->setMFile((string) $filename);
-                    $this->mStructs = array_merge(
-                        $this->mStructs,
-                        $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
-                    );
+                    $this->process_single_file($filename);
                 } catch(Exception $e) {
                     echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
                 }
             }
         } else {
             try {
-                $this->setMFile($file);
-                $this->mStructs = array_merge(
-                    $this->mStructs,
-                    $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
-                );
+                    $this->process_single_file($filename);
             } catch(Exception $e) {
                 echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
             }
         }
     }
+
+    private function process_single_file($filename)
+    {
+        if ($this->mOptions['v'] && $this->filecount > 1 && $this->filecount % 64 == 0) {
+            echo " ".$this->filecount." files\n";
+        }
+        $this->filecount++;
+
+        $startfile = microtime(true);
+
+        $this->setMFile((string) $filename);
+        $file = file_get_contents($this->mFile);
+        $md5 = md5($file);
+        if (isset($this->tagdata[$this->mFile][$md5])) {
+            // The file is the same as the previous time we analyzed and saved.
+            $this->mLines[$this->mFile] = $this->tagdata[$this->mFile][$md5];
+            if ($this->mOptions['v']) {
+                echo ".";
+            }
+            return;
+        }
+
+        $struct = $this->struct($this->mParser->parse($file), TRUE);
+        $finishfile = microtime(true);
+        $this->mLines[$this->mFile] = $this->render($struct);
+        $finishmerge = microtime(true);
+        $this->tagdata[$this->mFile][$md5] = $this->mLines[$this->mFile];
+        if ($this->mOptions['debug']) {
+            echo "Parse: ".($finishfile - $startfile).", Merge: ".($finishmerge-$finishfile)."; (".$this->filecount.")".$this->mFile."\n";
+        } else if ($this->mOptions['v']) {
+            echo "U";
+        }
+    }
+
 }
 
 class PHPCtagsException extends Exception {

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -368,8 +368,8 @@ class PHPCtags
             $str .= "\n";
         }
 
-        // remove the last line ending
-        $str = trim($str);
+        // remove the last line ending and carriage return
+        $str = trim(str_replace("\x0D", "", $str));
 
         return $str;
     }
@@ -379,7 +379,7 @@ class PHPCtags
 
         $str = '';
         foreach($this->mLines as $file => $data) {
-          $str .= $data;
+          $str .= $data."\n";
         }
 
         // sort the result as instructed
@@ -394,6 +394,9 @@ class PHPCtags
                 echo "\nSaved cache file.\n";
             }
         }
+
+        $str = trim($str);
+
         return $str;
     }
 

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -461,9 +461,9 @@ class PHPCtags
             }
         } else {
             try {
-                    $this->process_single_file($filename);
+                $this->process_single_file($file);
             } catch(Exception $e) {
-                echo "\nPHPParser: {$e->getMessage()} - {$filename}\n";
+                echo "\nPHPParser: {$e->getMessage()} - {$file}\n";
             }
         }
     }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -18,7 +18,7 @@ Exuberant Ctags compatiable PHP enhancement, Copyright (C) 2012 Techlive Zheng
 Addresses: <techlivezheng@gmail.com>, https://github.com/techlivezheng/phpctags
 EOF;
 
-$options = getopt('af:Nno:RuV', array(
+$options = getopt('aC:f:Nno:RuvV', array(
     'append::',
     'debug',
     'exclude:',
@@ -41,12 +41,14 @@ Usage: phpctags [options] [file(s)]
   -f <name>
        Write tags to specified file. Value of "-" writes tags to stdout
        ["tags"].
+  -C <name>
+       Use a cache file to store tags for faster updates.
   -n   Equivalent to --excmd=number.
   -N   Equivalent to --excmd=pattern.
   -o   Alternative for -f.
   -R   Equivalent to --recurse.
   -u   Equivalent to --sort=no.
-  -V   Equivalent to --verbose.
+  -v   Equivalent to --verbose.
   --append=[yes|no]
        Should tags should be appended to existing tag file [no]?
   --debug
@@ -75,6 +77,7 @@ EOF;
 
 // prune options and its value from the $argv array
 $argv_ = array();
+
 foreach ($options as $option => $value) {
   foreach ($argv as $key => $chunk) {
     $regex = '/^'. (isset($option[1]) ? '--' : '-') . $option . '/';
@@ -201,6 +204,7 @@ if (isset($options['R']) && empty($argv)) {
 try {
     $ctags = new PHPCtags($options);
     $ctags->addFiles($argv);
+    $ctags->setCacheFile(isset($options['C']) ? $options['C'] : null);
     $result = $ctags->export();
 } catch (Exception $e) {
     die("phpctags: {$e->getMessage()}".PHP_EOL);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -18,7 +18,7 @@ Exuberant Ctags compatiable PHP enhancement, Copyright (C) 2012 Techlive Zheng
 Addresses: <techlivezheng@gmail.com>, https://github.com/techlivezheng/phpctags
 EOF;
 
-$options = getopt('aC:f:Nno:RuvV', array(
+$options = getopt('aC:f:Nno:RuV', array(
     'append::',
     'debug',
     'exclude:',
@@ -28,6 +28,7 @@ $options = getopt('aC:f:Nno:RuvV', array(
     'help',
     'recurse::',
     'sort::',
+    'verbose::',
     'version',
     'memory::',
 ));
@@ -48,7 +49,7 @@ Usage: phpctags [options] [file(s)]
   -o   Alternative for -f.
   -R   Equivalent to --recurse.
   -u   Equivalent to --sort=no.
-  -v   Equivalent to --verbose.
+  -V   Equivalent to --verbose.
   --append=[yes|no]
        Should tags should be appended to existing tag file [no]?
   --debug
@@ -71,6 +72,8 @@ Usage: phpctags [options] [file(s)]
        Recurse into directories supplied on command line [no].
   --sort=[yes|no|foldcase]
        Should tags be sorted (optionally ignoring case) [yes]?.
+  --verbose=[yes|no]
+       Enable verbose messages describing actions on each source file.
   --version
        Print version identifier to standard output.
 EOF;
@@ -88,9 +91,17 @@ foreach ($options as $option => $value) {
 }
 while ($key = array_pop($argv_)) unset($argv[$key]);
 
-// option -V is an alternative to --version
+// option -V is an alternative to --verbose
 if (isset($options['V'])) {
-    $options['version'] = FALSE;
+    $options['verbose'] = 'yes';
+}
+
+if (isset($options['verbose'])) {
+    if ($options['verbose'] === FALSE || yes_or_no($options['verbose']) == 'yes') {
+        $options['V'] = 'yes';
+    } else if (yes_or_no($options['verbose']) != 'no') {
+        die('phpctags: Invalid value for "verbose" option'.PHP_EOL);
+    }
 }
 
 if (!isset($options['debug'])) {


### PR DESCRIPTION
Based on @mr-russ's PR https://github.com/vim-php/phpctags/pull/23 , I do the following changes:
1. Following ctags's behavior, use `-V` for verbose instead of `-v`
2. Use real path for `file_get_contents` and `file_exists` inside phar stub to avoid a weird PHP bug.
