### PR TITLE
Exclude phpctags when re-building phar

### DIFF
--- a/buildPHAR.php
+++ b/buildPHAR.php
@@ -34,6 +34,7 @@ $phar->buildFromIterator(
                     'build/*',
                     'tests/*',
                     'Makefile',
+                    'phpctags',
                     'phpctags.sh',
                     'buildPHAR.php',
                 );


### PR DESCRIPTION
Fixed the issue @mr-russ mentioned here https://github.com/vim-php/phpctags/pull/23#issuecomment-29704263.

Now, buildPHAR.php will ignore `phpctags` when build executable phar.