### PR TITLE
Ignore unreadable directories when traverse directory structure

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -385,7 +385,7 @@ class PHPCtags
     {
         if (is_dir($file) && isset($this->mOptions['R'])) {
             $iterator = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator(
+                new ReadableRecursiveDirectoryIterator(
                     $file,
                     FilesystemIterator::SKIP_DOTS |
                     FilesystemIterator::FOLLOW_SYMLINKS
@@ -432,3 +432,14 @@ class PHPCtagsException extends Exception {
         return "PHPCtags: {$this->message}\n";
     }
 }
+
+class ReadableRecursiveDirectoryIterator extends RecursiveDirectoryIterator {
+    function getChildren() {
+        try {
+            return new ReadableRecursiveDirectoryIterator($this->getPathname());
+        } catch(UnexpectedValueException $e) {
+            echo "\nPHPPCtags: {$e->getMessage()} - {$this->getPathname()}\n";
+            return new RecursiveArrayIterator(array());
+        }
+    }
+} 


### PR DESCRIPTION
PHPCtags will stop generating tags when parse unreadable folders currently, this commit will fix this issue. I referenced the code from here http://tw1.php.net/manual/zh/class.recursivedirectoryiterator.php#101654 .