### PR TITLE
Relative path works

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -291,7 +291,7 @@ class PHPCtags
         if (!empty($kind) && !empty($name) && !empty($line)) {
             $structs[] = array(
                 'file' => $this->mFile,
-                'rfile' => self::relativePath($this->mTagsDir, dirname($this->mFile)) . basename($this->mFile),
+                'rfile' => self::relativePath($this->mTagsDir, dirname($this->mFile)).DIRECTORY_SEPARATOR.basename($this->mFile),
                 'kind' => $kind,
                 'name' => $name,
                 'extends' => $extends,

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -33,8 +33,6 @@ class PHPCtags
         $this->mStructs = array();
         $this->mOptions = $options;
         $this->setMTagsDir();
-        echo $this->mOptions['f']."|";
-        echo $this->mTagsDir."|";
     }
 
     public function setMTagsDir()

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -198,6 +198,21 @@ if (isset($options['R']) && empty($argv)) {
     $argv[] = getcwd();
 }
 
+// write to a specified file
+if (isset($options['f']) && $options['f'] !== '-') {
+    $tagfile_name = $options['f'];
+    $append_mode = isset($options['a']) ? 'a' : 'w';
+// write to stdout only when instructed
+} else if (isset($options['f']) && $options['f'] === '-') {
+    $tagfile_name = 'php://stdout';
+    $append_mode = 'w';
+// write to file 'tags' by default
+} else {
+    $options['f'] = 'tags';
+    $tagfile_name = 'tags';
+    $append_mode = isset($options['a']) ? 'a' : 'w';
+}
+
 try {
     $ctags = new PHPCtags($options);
     $ctags->addFiles($argv);
@@ -206,16 +221,8 @@ try {
     die("phpctags: {$e->getMessage()}".PHP_EOL);
 }
 
-// write to a specified file
-if (isset($options['f']) && $options['f'] !== '-') {
-    $tagfile = fopen($options['f'], isset($options['a']) ? 'a' : 'w');
-// write to stdout only when instructed
-} else if (isset($options['f']) && $options['f'] === '-') {
-    $tagfile = fopen('php://stdout', 'w');
-// write to file 'tags' by default
-} else {
-    $tagfile = fopen('tags', isset($options['a']) ? 'a' : 'w');
-}
+// write to tag file
+$tagfile = fopen($options['f'], isset($options['a']) ? 'a' : 'w');
 
 $mode = ($options['sort'] == 'yes' ? 1 : ($options['sort'] == 'foldcase' ? 2 : 0));
 $tagline = <<<EOF

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -222,7 +222,7 @@ try {
 }
 
 // write to tag file
-$tagfile = fopen($options['f'], isset($options['a']) ? 'a' : 'w');
+$tagfile = fopen($tagfile_name, $append_mode);
 
 $mode = ($options['sort'] == 'yes' ? 1 : ($options['sort'] == 'foldcase' ? 2 : 0));
 $tagline = <<<EOF


### PR DESCRIPTION
Relative path works now.

According to (tagformat)[http://ctags.sourceforge.net/FORMAT], the path is relative to the current directory (or location of the tags file?). I use `relative to location of the tags file` here.
