### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ provide a patch for this.
 
 Installation is simple, make sure you have PHP's PHAR extension enabled, then
 just run `make` in the root directory of the source, you will get a `phpctags`
-PHAR executable, add it to your `$PATH`, then you can invoke `phpcatgs`
+PHAR executable, add it to your `$PATH`, then you can invoke `phpctags`
 directly from anywhere.
 
 See [phpctags on packagist](http://packagist.org/packages/techlivezheng/phpctags)


### PR DESCRIPTION
Corrected the invoke `phpctags` command