### PR TITLE
Make it installable via composer (without generate phar)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ tests/*.expect
 tests/*.result
 build/
 vendor/
-phpctags

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ source := README.md \
           ChangeLog.md \
           composer.json \
           composer.lock \
-          bootstrap.php \
+          phpctags \
           PHPCtags.class.php
 
 .PHONY: all

--- a/buildPHAR.php
+++ b/buildPHAR.php
@@ -52,5 +52,5 @@ $phar->buildFromIterator(
 );
 
 $phar->setStub(
-    "#!/usr/bin/env php\n".$phar->createDefaultStub('bootstrap.php')
+    "#!/usr/bin/env php\n".$phar->createDefaultStub('phpctags')
 );

--- a/phpctags
+++ b/phpctags
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 if (file_exists($autoload = __DIR__ . '/vendor/autoload.php')) {
     require($autoload);


### PR DESCRIPTION
Install globally via composer:
```
composer global require techlivezheng/phpctags
export PATH=~/.composer/vendor/bin:$PATH
```

http://akrabat.com/php/global-installation-of-php-tools-with-composer/
