### PR TITLE
fix glocal 5348key in function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ source := README.md \
           PHPCtags.class.php
 
 .PHONY: all
-all: phpctags
+all: clean phpctags
 
 .PHONY: clean
 clean:

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -106,11 +106,28 @@ class PHPCtags
     }
 
     private function getRealClassName($className){
-        if (isset($this->mUseConfig[$className])){
-            return  $this->mUseConfig[$className];
+        if (  $className[0] != "\\"  ){
+            $ret_arr=split("\\\\", $className , 2  );
+            if (count($ret_arr)==2){
+
+                $pack_name=$ret_arr[0];
+                if (isset($this->mUseConfig[ $pack_name])){
+                    return  $this->mUseConfig[$pack_name]."\\".$ret_arr[1] ;
+                }else{
+                    return $className;
+                }
+            }else{
+                if (isset($this->mUseConfig[$className])){
+                    return  $this->mUseConfig[$className];
+                }else{
+                    return $className;
+                }
+            }
+    
         }else{
             return $className;
         }
+
     }
     private function struct($node, $reset=FALSE, $parent=array())
     {
@@ -163,7 +180,7 @@ class PHPCtags
 
                                     /**  @var  $proNode PHPParser_Node_Stmt_Property  */
                                     $field_name=$matches[1];
-                                    $field_return_type=$matches[2];
+                                    $field_return_type= $this->getRealClassName( $matches[2]);
                                     $structs[] = array(
                                         'file' => $this->mFile,
                                         'kind' => "p",
@@ -189,7 +206,7 @@ class PHPCtags
             $name = $prop->name;
             $line = $prop->getLine();
             if ( preg_match( "/@var[ \t]+([a-zA-Z0-9_\\\\|]+)/",$node->getDocComment(), $matches) ){
-                $return_type=$matches[1];
+                $return_type=$this->getRealClassName( $matches[1]);
             }
 
             $access = $this->getNodeAccess($node);
@@ -204,7 +221,7 @@ class PHPCtags
             $line = $node->getLine();
             $access = $this->getNodeAccess($node);
             if ( preg_match( "/@return[ \t]+([a-zA-Z0-9_\\\\|]+)/",$node->getDocComment(), $matches) ){
-                $return_type=$matches[1];
+                $return_type=$this->getRealClassName( $matches[1]);
             }
             foreach ($node as $subNode) {
                 $this->struct($subNode, FALSE, array('method' => $name));
@@ -243,7 +260,7 @@ class PHPCtags
             $name = $node->name;
             $line = $node->getLine();
             if ( preg_match( "/@return[ \t]+([a-zA-Z0-9_\\\\|]+)/",$node->getDocComment(), $matches) ){
-                $return_type=$matches[1];
+                $return_type=$this->getRealClassName( $matches[1]);
             }
             foreach ($node as $subNode) {
                 $this->struct($subNode, FALSE, array('function' => $name));

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -264,7 +264,11 @@ class PHPCtags
             if (empty($struct['name']) || empty($struct['line']) || empty($struct['kind']))
                 return;
 
-            $str .= $struct['name'];
+            if  ($struct['name'] instanceof PHPParser_Node_Expr_Variable ){
+                $str .= $struct['name']->name;
+            }else{
+                $str .= $struct['name'];
+            }
 
             $str .= "\t" . $file;
 

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -119,6 +119,7 @@ class PHPCtags
         $return_type="";
         $implements = array();
 
+
         if (!empty($parent)) array_push($scope, $parent);
 
         if (is_array($node)) {
@@ -193,6 +194,9 @@ class PHPCtags
             $kind = 'f';
             $name = $node->name;
             $line = $node->getLine();
+            if ( preg_match( "/@return[ \t]+([a-zA-Z0-9_\\\\|]+)/",$node->getDocComment(), $matches) ){
+                $return_type=$matches[1];
+            }
             foreach ($node as $subNode) {
                 $this->struct($subNode, FALSE, array('function' => $name));
             }
@@ -383,16 +387,21 @@ class PHPCtags
                 $str .= "\t" . "type:" . $struct['type'] ;
             }
 
+
             $str .= "\n";
         }
+
 
         // remove the last line ending
         $str = trim($str);
 
+    /*
         // sort the result as instructed
         if (isset($this->mOptions['sort']) && ($this->mOptions['sort'] == 'yes' || $this->mOptions['sort'] == 'foldcase')) {
             $str = self::stringSortByLine($str, $this->mOptions['sort'] == 'foldcase');
         }
+
+    */
 
         return $str;
     }
@@ -407,7 +416,8 @@ class PHPCtags
             $this->process($file);
         }
 
-        return $this->render();
+        $ret=$this->render();
+        return $ret;
     }
 
     private function process($file)
@@ -456,6 +466,7 @@ class PHPCtags
         }
     }
 }
+  
 
 class PHPCtagsException extends Exception {
     public function __toString() {

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -482,7 +482,7 @@ class PHPCtags
                     $this->struct($ret_tree, TRUE)
                 );
             } catch(Exception $e) {
-                echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;
+                echo "PHPParser: {$e->getMessage()} - {$file}".PHP_EOL;
             }
         }
     }

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -149,6 +149,8 @@ class PHPCtags
             $implements = $node->implements;
             $line = $node->getLine();
 
+            $filed_scope=$scope;
+            array_push($filed_scope, array('class' => $name ) );
             foreach ($node as $key=> $subNode) {
                 if ($key=="stmts"){
                     foreach ($subNode as $tmpNode) {
@@ -169,7 +171,7 @@ class PHPCtags
                                         'extends' => null,
                                         'implements' => null,
                                         'line' => $comment->getLine() ,
-                                        'scope' => null,
+                                        'scope' => $filed_scope ,
                                         'access' => "public",
                                         'type' => $field_return_type,
                                     );

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -113,7 +113,10 @@ class PHPCtags
             $structs = array();
         }
 
+        /*$node::PHPParser_Node_Stmt_Class  */
+        
         $kind = $name = $line = $access = $extends = '';
+        $return_type="";
         $implements = array();
 
         if (!empty($parent)) array_push($scope, $parent);
@@ -136,6 +139,10 @@ class PHPCtags
             $prop = $node->props[0];
             $name = $prop->name;
             $line = $prop->getLine();
+            if ( preg_match( "/@var[ \t]+([a-zA-Z0-9_\\\\|]+)/",$node->getDocComment(), $matches) ){
+                $return_type=$matches[1];
+            }
+
             $access = $this->getNodeAccess($node);
         } elseif ($node instanceof PHPParser_Node_Stmt_ClassConst) {
             $kind = 'd';
@@ -147,6 +154,9 @@ class PHPCtags
             $name = $node->name;
             $line = $node->getLine();
             $access = $this->getNodeAccess($node);
+            if ( preg_match( "/@return[ \t]+([a-zA-Z0-9_\\\\|]+)/",$node->getDocComment(), $matches) ){
+                $return_type=$matches[1];
+            }
             foreach ($node as $subNode) {
                 $this->struct($subNode, FALSE, array('method' => $name));
             }
@@ -246,6 +256,7 @@ class PHPCtags
                 'line' => $line,
                 'scope' => $scope,
                 'access' => $access,
+                'type' => $return_type,
             );
         }
 
@@ -365,6 +376,11 @@ class PHPCtags
             #field=a
             if (in_array('a', $this->mOptions['fields']) && !empty($struct['access'])) {
                 $str .= "\t" . "access:" . $struct['access'];
+            }
+
+            #type
+            if ( !empty($struct['type'])) {
+                $str .= "\t" . "type:" . $struct['type'] ;
             }
 
             $str .= "\n";

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -154,16 +154,23 @@ class PHPCtags
             foreach ($node as $subNode) {
                 $this->struct($subNode);
             }
+        } elseif ($node instanceof PHPParser_Node_Expr_LogicalOr ) {
+            foreach ($node as $subNode) {
+                $this->struct($subNode);
+            }
+
         } elseif ($node instanceof PHPParser_Node_Stmt_Const) {
             $kind = 'd';
             $cons = $node->consts[0];
             $name = $cons->name;
             $line = $node->getLine();
         } elseif ($node instanceof PHPParser_Node_Stmt_Global) {
+            /*
             $kind = 'v';
             $prop = $node->vars[0];
             $name = $prop->name;
             $line = $node->getLine();
+            */
         } elseif ($node instanceof PHPParser_Node_Stmt_Static) {
             //@todo
         } elseif ($node instanceof PHPParser_Node_Stmt_Declare) {
@@ -420,9 +427,10 @@ class PHPCtags
         } else {
             try {
                 $this->setMFile($file);
+                $ret_tree= $this->mParser->parse(file_get_contents($this->mFile));
                 $this->mStructs = array_merge(
                     $this->mStructs,
-                    $this->struct($this->mParser->parse(file_get_contents($this->mFile)), TRUE)
+                    $this->struct($ret_tree, TRUE)
                 );
             } catch(Exception $e) {
                 echo "PHPParser: {$e->getMessage()} - {$filename}".PHP_EOL;

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -148,7 +148,37 @@ class PHPCtags
             $extends = $node->extends;
             $implements = $node->implements;
             $line = $node->getLine();
-            foreach ($node as $subNode) {
+
+            foreach ($node as $key=> $subNode) {
+                if ($key=="stmts"){
+                    foreach ($subNode as $tmpNode) {
+                        $comments=$tmpNode->getAttribute("comments");
+                        if (is_array($comments)){
+                            foreach( $comments  as $comment ){
+                                if ( preg_match(
+                                    "/@var[ \t]+\\$([a-zA-Z0-9_]+)[ \t]+([a-zA-Z0-9_\\\\]+)/",
+                                    $comment->getText(), $matches) ){
+
+                                    /**  @var  $proNode PHPParser_Node_Stmt_Property  */
+                                    $field_name=$matches[1];
+                                    $field_return_type=$matches[2];
+                                    $structs[] = array(
+                                        'file' => $this->mFile,
+                                        'kind' => "p",
+                                        'name' => $field_name,
+                                        'extends' => null,
+                                        'implements' => null,
+                                        'line' => $comment->getLine() ,
+                                        'scope' => null,
+                                        'access' => "public",
+                                        'type' => $field_return_type,
+                                    );
+
+                                }
+                            }
+                        }
+                    }
+                }
                 $this->struct($subNode, FALSE, array('class' => $name));
             }
         } elseif ($node instanceof PHPParser_Node_Stmt_Property) {

--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -207,6 +207,7 @@ class PHPCtags
             foreach ($node as $subNode) {
                 $this->struct($subNode, FALSE, array('namespace' => $name));
             }
+            /*
         } elseif ($node instanceof PHPParser_Node_Expr_Assign) {
             if (is_string($node->var->name)) {
                 $kind = 'v';
@@ -221,6 +222,7 @@ class PHPCtags
                 $name = $node->name;
                 $line = $node->getLine();
             }
+            */
         } elseif ($node instanceof PHPParser_Node_Expr_FuncCall) {
             switch ($node->name) {
                 case 'define':

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -199,8 +199,10 @@ if (isset($options['R']) && empty($argv)) {
 }
 
 try {
+
     $ctags = new PHPCtags($options);
     $ctags->addFiles($argv);
+
     $result = $ctags->export();
 } catch (Exception $e) {
     die("phpctags: {$e->getMessage()}".PHP_EOL);
@@ -227,7 +229,7 @@ $tagline = <<<EOF
 !_TAG_PROGRAM_VERSION\t${version}\t//\n
 EOF;
 
-fwrite($tagfile, $tagline.$result);
+$ret=fwrite($tagfile, $tagline.$result);
 fclose($tagfile);
 
 function yes_or_no($arg) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,6 +11,8 @@ if (file_exists($autoload = __DIR__ . '/vendor/autoload.php')) {
     );
 }
 
+
+
 $version = PHPCtags::VERSION;
 
 $copyright = <<<'EOF'
@@ -91,7 +93,7 @@ if (isset($options['V'])) {
 }
 
 if (!isset($options['debug'])) {
-    error_reporting(0);
+    //error_reporting(0);
 }
 
 if (isset($options['help'])) {
@@ -140,7 +142,7 @@ if (!isset($options['excmd']))
 if (!isset($options['format']))
     $options['format'] = 2;
 if (!isset($options['memory']))
-    $options['memory'] = '128M';
+    $options['memory'] = '1024M';
 if (!isset($options['fields'])) {
     $options['fields'] = array('n', 'k', 's', 'a','i');
 } else {
@@ -193,21 +195,24 @@ if (isset($options['recurse'])) {
     }
 }
 
+
 // if option -R is given and no file is specified, use current working directory
 if (isset($options['R']) && empty($argv)) {
     $argv[] = getcwd();
 }
+
 
 try {
 
     $ctags = new PHPCtags($options);
     $ctags->addFiles($argv);
 
+
+
     $result = $ctags->export();
 } catch (Exception $e) {
     die("phpctags: {$e->getMessage()}".PHP_EOL);
 }
-
 // write to a specified file
 if (isset($options['f']) && $options['f'] !== '-') {
     $tagfile = fopen($options['f'], isset($options['a']) ? 'a' : 'w');


### PR DESCRIPTION
fix this bug


localhost:~$ cat a.php
<?php
$v1=10;
$v2=12;
function xxxx ( $g_key){
global $$g_key;
return $$g_key;
}
echo xxxx("v1" ) ."\n";

localhost:~$ php a.php
10

localhost:~$ phpctags --debug a.php
PHP Catchable fatal error: Object of class PHPParser_Node_Expr_Variable could not be converted to string in phar:///home/jim/bin/phpctags/PHPCtags.class.php on line 267

