### PR TITLE
Define new build flow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .test_fs
 build/
 vendor/
-./phpctags

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,11 @@ source := README.md \
           PHPCtags.class.php
 
 .PHONY: all
-all: phpctags
+all: build/phpctags.phar
 
 .PHONY: clean
 clean:
 	@echo "Cleaning executables ..."
-	@rm -f ./phpctags
 	@rm -f ./build/phpctags.phar
 	@echo "Done!"
 
@@ -20,7 +19,6 @@ dist-clean:
 	@echo "Cleaning old build files and vendor libraries ..."
 	@rm -rf ./build
 	@rm -rf ./vendor
-	@rm -f  ./phpctags
 	@echo "Done!"
 
 .PHONY: install
@@ -45,8 +43,3 @@ vendor: composer.lock build/composer.phar
 build/phpctags.phar: vendor $(source) | build
 	@php -dphar.readonly=0 buildPHAR.php
 	@chmod +x build/phpctags.phar
-
-phpctags: build/phpctags.phar
-	@echo "Building phpctags ..."
-	@cp build/phpctags.phar phpctags
-	@echo "Done!"

--- a/buildPHAR.php
+++ b/buildPHAR.php
@@ -35,8 +35,6 @@ $phar->buildFromIterator(
                     'tests/*',
                     'Makefile',
                     'bin/phpctags',
-                    'phpctags',
-                    'phpctags.sh',
                     'buildPHAR.php',
                 );
 


### PR DESCRIPTION
During my tests I have seen a lot of methods to build this package.
I have choosen one simple flow.
bin/phpctags is the composer entry point of console application..
You can use it if you install this application with composer.
make command build into the /build directory a phar archive of application