### PR TITLE
Updating version constant to match the version tag

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -1,7 +1,7 @@
 <?php
 class PHPCtags
 {
-    const VERSION = '0.5.1';
+    const VERSION = '0.6.0';
 
     private $mFile;
 


### PR DESCRIPTION
The class constant value was out of sync. :confused:

`0.5.1` -> `0.6.0`