### PR TITLE
Add support to specify new file formats, or to ignore, defaults

### DIFF
--- a/PHPCtags.class.php
+++ b/PHPCtags.class.php
@@ -445,7 +445,7 @@ class PHPCtags
                 )
             );
 
-            $extensions = array('.php', '.php3', '.php4', '.php5', '.phps');
+            $extensions = $this->mOptions['extensions'];
 
             foreach ($iterator as $filename) {
                 if (!in_array(substr($filename, strrpos($filename, '.')), $extensions)) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -25,6 +25,7 @@ $options = getopt('aC:f:Nno:RuV', array(
     'excmd::',
     'fields::',
     'kinds::',
+    'extensions::',
     'format::',
     'help',
     'recurse::',
@@ -64,6 +65,8 @@ Usage: phpctags [options] [file(s)]
        Include selected extension fields (flags: "afmikKlnsStz") [fks].
   --kinds=[+|-]flags
        Enable/disable tag kinds [cmfpvditn]
+  --extensions=[+|-]extension[,[+|-]]extension
+       Enable/disable file extensions [+.php,+.php3,+.php4,+.php5,+.phps]
   --format=level
        Force output of specified tag file format [2].
   --help
@@ -177,6 +180,22 @@ if (!isset($options['kinds'])) {
     $options['kinds'] = str_split($options['kinds']);
 }
 
+$default_extensions = array('.php', '.php3', '.php4', '.php5', '.phps');
+if (!isset($options['extensions'])) {
+    $options['extensions'] = $default_extensions;
+} else {
+    $extensions = explode(',', $options['extensions']);
+    $options['extensions'] = $default_extensions;
+    foreach ($extensions as $ext) {
+        if ($ext[0] == '+') {
+            $options['extensions'][] = substr($ext, 1);
+        } elseif ($ext[0] == '-') {
+            $options['extensions'] = array_diff($options['extensions'], array(substr($ext, 1)));
+        } else {
+            die('phpctags: Invalid value for "extensions" option ' . $ext . PHP_EOL);
+        }
+    }
+}
 
 // handle -u or --sort options
 if (isset($options['sort'])) {

--- a/tests/Acceptance/ExtensionsText.php
+++ b/tests/Acceptance/ExtensionsText.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace tests\PHPCTags\Acceptance;
+
+final class ExtensionsTest extends AcceptanceTestCase
+{
+    /**
+     * @test
+     */
+    public function itUsesDefaultExtensions()
+    {
+        $this->givenSourceFile('new_extension.inc', <<<EOS
+<?php
+
+class TestClass 
+{
+	function publicMethod() {
+        }
+}
+EOS
+        );
+
+        $this->runPHPCtags();
+        $this->assertTagsFileHeaderIsCorrect();
+
+        $this->assertTagsFileContainsNoTagsFromFile('new_extension.inc');
+    }
+
+    /**
+     * @test
+     */
+    public function itUsesCustomExtensions()
+    {
+        $this->givenSourceFile('new_extension.inc', <<<EOS
+<?php
+
+class TestClass 
+{
+	public function publicMethod() {
+        }
+}
+EOS
+        );
+
+        $this->runPHPCtags(array('--extensions=+.inc'));
+        $this->assertTagsFileHeaderIsCorrect();
+        $this->assertNumberOfTagsInTagsFileIs(2);
+
+        $this->assertTagsFileContainsTag(
+            'new_extension.inc',
+            'TestClass',
+            self::KIND_CLASS,
+            3
+        );
+        $this->assertTagsFileContainsTag(
+            'new_extension.inc',
+            'publicMethod',
+            self::KIND_METHOD,
+            5,
+            'class:TestClass',
+            'public'
+        );
+    }
+}


### PR DESCRIPTION
Projects I work on still use archaic file extensions, specifically '.inc'.  This commit allows me to add .inc files to be pulled in when recursing through the directory structure.