### PR TITLE
Added php implementation of fnmatch for platforms not supporting it.

### DIFF
--- a/buildPHAR.php
+++ b/buildPHAR.php
@@ -1,21 +1,89 @@
 <?php
+// fnmatch implementation taken from:
+// https://www.php.net/manual/en/function.fnmatch.php#100207
+if (!function_exists('fnmatch'))
+    define('FNM_PATHNAME', 1);
+    define('FNM_NOESCAPE', 2);
+    define('FNM_PERIOD', 4);
+    define('FNM_CASEFOLD', 16);
+
+    function fnmatch($pattern, $string, $flags=0)
+    {
+        return pcre_fnmatch($pattern, $string, $flags);
+    }
+}
+
+function pcre_fnmatch($pattern, $string, $flags = 0)
+{
+    $modifiers = null;
+    $transforms = array(
+        '\*' => '.*',
+        '\?' => '.',
+        '\[\!' => '[^',
+        '\[' => '[',
+        '\]' => ']',
+        '\.' => '\.',
+        '\\' => '\\\\'
+    );
+
+    // Forward slash in string must be in pattern:
+    if ($flags & FNM_PATHNAME) {
+        $transforms['\*'] = '[^/]*';
+    }
+
+    // Back slash should not be escaped:
+    if ($flags & FNM_NOESCAPE) {
+        unset($transforms['\\']);
+    }
+
+    // Perform case insensitive match:
+    if ($flags & FNM_CASEFOLD) {
+        $modifiers .= 'i';
+    }
+
+    // Period at start must be the same as pattern:
+    if ($flags & FNM_PERIOD) {
+        if (strpos($string, '.') === 0 && strpos($pattern, '.') !== 0) {
+            return false;
+        }
+    }
+
+    $pattern = '#^'
+        . strtr(preg_quote($pattern, '#'), $transforms)
+        . '$#'
+        . $modifiers
+    ;
+
+    return (boolean)preg_match($pattern, $string);
+}
 
 $phar = new Phar('build/phpctags.phar', 0, 'phpctags.phar');
 
 if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-    class RecursiveCallbackFilterIterator extends RecursiveFilterIterator {
-        public function __construct ( RecursiveIterator $iterator, $callback ) {
+    class RecursiveCallbackFilterIterator extends RecursiveFilterIterator
+    {
+        public function __construct(RecursiveIterator $iterator, $callback)
+        {
             $this->callback = $callback;
             parent::__construct($iterator);
         }
 
-        public function accept () {
+        public function accept()
+        {
             $callback = $this->callback;
-            return $callback(parent::current(), parent::key(), parent::getInnerIterator());
+            return $callback(
+                parent::current(),
+                parent::key(),
+                parent::getInnerIterator()
+            );
         }
 
-        public function getChildren () {
-            return new self($this->getInnerIterator()->getChildren(), $this->callback);
+        public function getChildren()
+        {
+            return new self(
+                $this->getInnerIterator()->getChildren(),
+                $this->callback
+            );
         }
     }
 }
@@ -38,7 +106,7 @@ $phar->buildFromIterator(
                     'buildPHAR.php',
                 );
 
-                foreach($excludes as $exclude) {
+                foreach ($excludes as $exclude) {
                     if (fnmatch(getcwd().'/'.$exclude, $current->getPathName())) {
                         return false;
                     }


### PR DESCRIPTION
So I have spend some time playing around with Samsung Dex and configuring my phone as a development machine that is portable and power efficient amd I found about this project in the process
of discovering the best auto completion method that would work properly on vim on android.
But couldn't build the phpctags phar file because it seems that the androind platform or the
php build that is shipped with termux app repository doesn't supports fnmatch.

Took the fnmatch php implementation from the php.net comments section and added a link
on the comments of the source. Sorry if I messed the formatting a bit, but I just ran a default
configuration of php-cs-fixer after having to remove lots of characters that where causing errors
do to copy pasting from php.net site to the Termux android app which seems to not have proper copy/pasting support.